### PR TITLE
Add short form aliases -i and -e for --include and --exclude

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,10 +21,10 @@ func Execute() error {
 
 func init() {
 	rootCmd.PersistentFlags().IntVarP(&batchSize, "batch-size", "b", 25, "Number of contexts to process in parallel")
-	rootCmd.PersistentFlags().StringArrayVar(&filterPatterns, "include", []string{}, "Include contexts by name using regex pattern (can be specified multiple times for OR logic)")
+	rootCmd.PersistentFlags().StringArrayVarP(&filterPatterns, "include", "i", []string{}, "Include contexts by name using regex pattern (can be specified multiple times for OR logic)")
 	rootCmd.PersistentFlags().StringArrayVar(&filterPatterns, "filter", []string{}, "Alias for --include")
 	rootCmd.PersistentFlags().MarkDeprecated("filter", "use --include instead")
-	rootCmd.PersistentFlags().StringArrayVar(&excludePatterns, "exclude", []string{}, "Exclude contexts by name using regex pattern (can be specified multiple times for OR logic)")
+	rootCmd.PersistentFlags().StringArrayVarP(&excludePatterns, "exclude", "e", []string{}, "Exclude contexts by name using regex pattern (can be specified multiple times for OR logic)")
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(getCmd)
 	rootCmd.AddCommand(logsCmd)


### PR DESCRIPTION
## Summary
- Adds `-i` as a short alias for `--include`
- Adds `-e` as a short alias for `--exclude`

Closes #64

## Test plan
- [ ] `kubectl x -i mycontext get pods` works the same as `kubectl x --include mycontext get pods`
- [ ] `kubectl x -e mycontext get pods` works the same as `kubectl x --exclude mycontext get pods`
- [ ] Help output shows the new short flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)