### PR TITLE
Warn when --sort-by is used that results may not be globally sorted

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -125,7 +125,20 @@ func (p *progressBar) finish() {
 	<-p.done
 }
 
+func hasSortBy(args []string) bool {
+	for _, arg := range args {
+		if arg == "--sort-by" || strings.HasPrefix(arg, "--sort-by=") {
+			return true
+		}
+	}
+	return false
+}
+
 func runCommand(subcommand string, extraArgs []string) error {
+	if hasSortBy(extraArgs) {
+		fmt.Fprintf(os.Stderr, "Warning: --sort-by sorts within each context independently and may not produce the expected global ordering. See https://github.com/platformersdev/kubectl-x/issues/29\n")
+	}
+
 	contexts, err := getContexts()
 	if err != nil {
 		return fmt.Errorf("failed to get contexts: %w", err)


### PR DESCRIPTION
## Summary
- Adds a warning to stderr when `--sort-by` is passed, explaining that it only sorts within each context independently and may not produce the expected global ordering
- Links to #29 for more context

Closes #68

## Test plan
- [ ] `kubectl x get pods --sort-by=.metadata.name` prints a warning to stderr
- [ ] `kubectl x get pods --sort-by .metadata.name` (space-separated) prints a warning to stderr
- [ ] Commands without `--sort-by` produce no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)