### PR TITLE
Add auth subcommand support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A kubectl plugin that runs commands against every context in your kubeconfig fil
 - Run kubectl commands against all contexts simultaneously
 - Parallel execution with configurable batching (default: 25 contexts at a time)
 - Include/exclude contexts by name pattern
-- Support for `version`, `get`, `logs`, `wait`, `top`, `events`, `api-resources`, and `api-versions` subcommands
+- Support for `version`, `get`, `logs`, `wait`, `top`, `events`, `api-resources`, `api-versions`, and `auth` subcommands
 - Streaming log output with `-f` flag across all contexts
 - Watch mode with `-w`/`--watch` flag on `get` and `events` subcommands
 - Flexible output formatting:
@@ -236,6 +236,20 @@ Run `kubectl api-versions` against all contexts:
 ```bash
 # List all API versions from all contexts
 kubectl x api-versions
+```
+
+### Auth Command
+
+Run `kubectl auth` subcommands against all contexts:
+
+```bash
+# Show the current authenticated user across all contexts
+kubectl x auth whoami
+
+# Check if the current user can perform an action across all contexts
+kubectl x auth can-i get pods
+kubectl x auth can-i create deployments -n default
+kubectl x auth can-i '*' '*'
 ```
 
 ## Output Formats

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var authCmd = &cobra.Command{
+	Use:                "auth",
+	Short:              "Run kubectl auth subcommands against all contexts",
+	Long:               `Run kubectl auth subcommands (e.g. whoami, can-i) against all contexts in parallel.`,
+	DisableFlagParsing: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runCommand("auth", args)
+	},
+}

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthCmd(t *testing.T) {
+	require.NotNil(t, authCmd)
+	assert.Equal(t, "auth", authCmd.Use)
+	assert.True(t, authCmd.DisableFlagParsing)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,4 +33,5 @@ func init() {
 	rootCmd.AddCommand(eventsCmd)
 	rootCmd.AddCommand(apiResourcesCmd)
 	rootCmd.AddCommand(apiVersionsCmd)
+	rootCmd.AddCommand(authCmd)
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -14,7 +14,7 @@ func TestRootCmd(t *testing.T) {
 }
 
 func TestRootCmdHasSubcommands(t *testing.T) {
-	expected := []string{"version", "get", "logs", "top", "wait", "events", "api-resources", "api-versions"}
+	expected := []string{"version", "get", "logs", "top", "wait", "events", "api-resources", "api-versions", "auth"}
 	registered := make(map[string]bool)
 	for _, cmd := range rootCmd.Commands() {
 		registered[cmd.Use] = true


### PR DESCRIPTION
## Summary
- Adds `kubectl x auth` subcommand that forwards all args to `kubectl auth`
- Supports `whoami`, `can-i`, and any other `auth` subcommands kubectl supports
- Updates README with feature list entry and usage examples

Closes #71